### PR TITLE
Report coverage only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
 - 5.4
 - 5.5
 - 5.6
+  env: COLLECT_COVERAGE=true
 - 7
 
 sudo: false
@@ -16,7 +17,7 @@ install:
 - composer require satooshi/php-coveralls --dev
 
 script:
-- php vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml
+- if [[ "$COLLECT_COVERAGE" == "true" ]]; then php vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml; else php vendor/phpunit/phpunit/phpunit fi
 
 after_script:
-- php vendor/bin/coveralls
+- if [[ "$COLLECT_COVERAGE" == "true" ]]; then php vendor/bin/coveralls fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: php
 
-php:
-- 5.4
-- 5.5
-- 5.6
-  env: COLLECT_COVERAGE=true
-- 7
+matrix:
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+      env: COLLECT_COVERAGE=true
+    - php: 7
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 - composer require satooshi/php-coveralls --dev
 
 script:
-- if [[ "$COLLECT_COVERAGE" == "true" ]]; then php vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml else php vendor/phpunit/phpunit/phpunit fi
+- if [[ "$COLLECT_COVERAGE" == "true" ]]; then php vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml; else php vendor/phpunit/phpunit/phpunit; fi
 
 after_script:
-- if [[ "$COLLECT_COVERAGE" == "true" ]]; then php vendor/bin/coveralls fi
+- if [[ "$COLLECT_COVERAGE" == "true" ]]; then php vendor/bin/coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 - composer require satooshi/php-coveralls --dev
 
 script:
-- if [[ "$COLLECT_COVERAGE" == "true" ]]; then php vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml; else php vendor/phpunit/phpunit/phpunit fi
+- if [[ "$COLLECT_COVERAGE" == "true" ]]; then php vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml else php vendor/phpunit/phpunit/phpunit fi
 
 after_script:
 - if [[ "$COLLECT_COVERAGE" == "true" ]]; then php vendor/bin/coveralls fi


### PR DESCRIPTION
Only the PHP 5.6 build will report the code coverage to coveralls.io so this speeds up the builds and reduces the cpu costs for travis.