### PR TITLE
Full array and string access

### DIFF
--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -2,6 +2,7 @@
 
 namespace Art4\JsonApiClient;
 
+use Art4\JsonApiClient\Resource\Collection;
 use Art4\JsonApiClient\Utils\AccessTrait;
 use Art4\JsonApiClient\Utils\MetaTrait;
 use Art4\JsonApiClient\Utils\LinksTrait;
@@ -179,24 +180,17 @@ class Relationship implements AccessInterface
 
 		if ( is_array($data) )
 		{
-			$resource_array = array();
-
-			if ( count($data) > 0 )
+			$collection = new Collection($data);
+			foreach ($collection->getKeys() as $key)
 			{
-				foreach ($data as $data_obj)
+				$obj = $collection->get($key);
+				if (!$obj instanceof Identifier)
 				{
-					$resource_obj = $this->parseData($data_obj);
-
-					if ( ! ($resource_obj instanceof Identifier) )
-					{
-						throw new ValidationException('Data has to be instance of "Resource\\Identifier", "' . gettype($data) . '" given.');
-					}
-
-					$resource_array[] = $resource_obj;
+					throw new ValidationException('Data has to be instance of "Resource\\Identifier", "' . gettype($obj) . '" given.');
 				}
 			}
 
-			return $resource_array;
+			return $collection;
 		}
 
 		if ( ! is_object($data) )

--- a/src/Utils/AccessTrait.php
+++ b/src/Utils/AccessTrait.php
@@ -18,9 +18,34 @@ trait AccessTrait
 
 		foreach($this->getKeys() as $key)
 		{
-			$return[$key] = $this->get($key);
+			$val = $this->get($key);
+
+			if (!is_object($val))
+			{
+				$return[$key] = $val;
+			}
+			elseif (is_callable([$val, 'asArray']))
+			{
+				$return[$key] = $val->asArray();
+			}
+			else
+			{
+				// Fallback for stdClass objects
+				$return[$key] = json_decode(json_encode($val), true);
+			}
+
 		}
 
 		return $return;
+	}
+
+	/**
+	 * Convert object in a json string
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		return json_encode($this->asArray());
 	}
 }

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -208,16 +208,16 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
 		$data_array = $comments->get('data');
 
-		$this->assertTrue(is_array($data_array));
-		$this->assertTrue(count($data_array) === 2);
+		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Collection', $data_array);
+		$this->assertCount(2, $data_array->getKeys());
 
-		$identifier = $data_array[0];
+		$identifier = $data_array->get(0);
 
 		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Identifier', $identifier);
 		$this->assertSame($identifier->get('type'), 'comments');
 		$this->assertSame($identifier->get('id'), '5');
 
-		$identifier = $data_array[1];
+		$identifier = $data_array->get(1);
 
 		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Identifier', $identifier);
 		$this->assertSame($identifier->get('type'), 'comments');

--- a/tests/unit/AttributesTest.php
+++ b/tests/unit/AttributesTest.php
@@ -47,7 +47,7 @@ class AttributesTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($attributes->getKeys(), array('object', 'array', 'string', 'number_int', 'number_float', 'true', 'false', 'null'));
 
 		$this->assertSame($attributes->asArray(), array(
-			'object' => $attributes->get('object'),
+			'object' => json_decode(json_encode($attributes->get('object')), true),
 			'array' => $attributes->get('array'),
 			'string' => $attributes->get('string'),
 			'number_int' => $attributes->get('number_int'),

--- a/tests/unit/DocumentLinkTest.php
+++ b/tests/unit/DocumentLinkTest.php
@@ -42,7 +42,7 @@ class DocumentLinkTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($link->asArray(), array(
 			'self' => $link->get('self'),
 			'related' => $link->get('related'),
-			'pagination' => $link->get('pagination'),
+			'pagination' => $link->get('pagination')->asArray(),
 		));
 	}
 

--- a/tests/unit/DocumentTest.php
+++ b/tests/unit/DocumentTest.php
@@ -32,7 +32,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
 		$this->assertFalse($document->has('included'));
 
 		$this->assertSame($document->asArray(), array(
-			'meta' => $document->get('meta'),
+			'meta' => $document->get('meta')->asArray(),
 		));
 	}
 
@@ -187,8 +187,9 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
 		$this->assertTrue($collection->isCollection());
 		$this->assertTrue(count($collection->asArray()) === 1);
 
-		foreach ($collection->asArray() as $resource)
+		foreach ($collection->getKeys() as $key)
 		{
+			$resource = $collection->get($key);
 			$this->assertInstanceOf('Art4\JsonApiClient\Resource\ResourceInterface', $resource);
 			$this->assertInstanceOf('Art4\JsonApiClient\Resource\Identifier', $resource);
 		}
@@ -221,8 +222,9 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
 		$this->assertTrue($collection->isCollection());
 		$this->assertTrue(count($collection->asArray()) === 1);
 
-		foreach ($collection->asArray() as $resource)
+		foreach ($collection->getKeys() as $key)
 		{
+			$resource = $collection->get($key);
 			$this->assertInstanceOf('Art4\JsonApiClient\Resource\ResourceInterface', $resource);
 			$this->assertInstanceOf('Art4\JsonApiClient\Resource\Item', $resource);
 		}
@@ -394,9 +396,8 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
 		$this->assertTrue(count($resources->asArray()) === 2);
 		$this->assertSame($resources->getKeys(), array(0, 1));
 
-		foreach ($resources->asArray() as $resource)
-		{
-			$this->assertInstanceOf('Art4\JsonApiClient\Resource\Identifier', $resource);
+		foreach ($resources->getKeys() as $key) {
+			$this->assertInstanceOf('Art4\JsonApiClient\Resource\Identifier', $resources->get($key));
 		}
 	}
 

--- a/tests/unit/ErrorCollectionTest.php
+++ b/tests/unit/ErrorCollectionTest.php
@@ -38,8 +38,8 @@ class ErrorCollectionTest extends \PHPUnit_Framework_TestCase
 		$this->assertInstanceOf('Art4\JsonApiClient\Error', $error);
 
 		$this->assertSame($collection->asArray(), array(
-			$collection->get(0),
-			$collection->get(1),
+			$collection->get(0)->asArray(),
+			$collection->get(1)->asArray(),
 		));
 	}
 

--- a/tests/unit/ErrorTest.php
+++ b/tests/unit/ErrorTest.php
@@ -50,13 +50,13 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertSame($error->asArray(), array(
 			'id'     => 'id',
-			'links'  => $error->get('links'),
+			'links'  => $error->get('links')->asArray(),
 			'status' => 'status',
 			'code'   => 'code',
 			'title'  => 'title',
 			'detail' => 'detail',
-			'source' => $error->get('source'),
-			'meta'   => $error->get('meta'),
+			'source' => $error->get('source')->asArray(),
+			'meta'   => $error->get('meta')->asArray(),
 		));
 	}
 

--- a/tests/unit/JsonapiTest.php
+++ b/tests/unit/JsonapiTest.php
@@ -39,7 +39,7 @@ class JsonapiTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertSame($jsonapi->asArray(), array(
 			'version' => $jsonapi->get('version'),
-			'meta' => $jsonapi->get('meta'),
+			'meta' => $jsonapi->get('meta')->asArray(),
 		));
 	}
 

--- a/tests/unit/LinkTest.php
+++ b/tests/unit/LinkTest.php
@@ -37,9 +37,9 @@ class LinkTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertSame($link->asArray(), array(
 			'href' => $link->get('href'),
-			'linkobj' => $link->get('linkobj'),
+			'linkobj' => $link->get('linkobj')->asArray(),
 			'link' => $link->get('link'),
-			'meta' => $link->get('meta'),
+			'meta' => $link->get('meta')->asArray(),
 		));
 	}
 

--- a/tests/unit/MetaTest.php
+++ b/tests/unit/MetaTest.php
@@ -48,7 +48,7 @@ class MetaTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($meta->getKeys(), array('object', 'array', 'string', 'number_int', 'number_float', 'true', 'false', 'null'));
 
 		$this->assertSame($meta->asArray(), array(
-			'object' => $meta->get('object'),
+			'object' => json_decode(json_encode($meta->get('object')), true),
 			'array' => array(),
 			'string' => 'string',
 			'number_int' => 654,

--- a/tests/unit/RelationshipCollectionTest.php
+++ b/tests/unit/RelationshipCollectionTest.php
@@ -36,7 +36,7 @@ class RelationshipCollectionTest extends \PHPUnit_Framework_TestCase
 		$this->assertInstanceOf('Art4\JsonApiClient\Relationship', $collection->get('author'));
 
 		$this->assertSame($collection->asArray(), array(
-			'author' => $collection->get('author'),
+			'author' => $collection->get('author')->asArray(),
 		));
 	}
 

--- a/tests/unit/RelationshipLinkTest.php
+++ b/tests/unit/RelationshipLinkTest.php
@@ -46,7 +46,7 @@ class RelationshipLinkTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($link->asArray(), array(
 			'self' => $link->get('self'),
 			'related' => $link->get('related'),
-			'pagination' => $link->get('pagination'),
+			'pagination' => $link->get('pagination')->asArray(),
 		));
 	}
 

--- a/tests/unit/RelationshipTest.php
+++ b/tests/unit/RelationshipTest.php
@@ -141,8 +141,8 @@ class RelationshipTest extends \PHPUnit_Framework_TestCase
 
 		$resources = $relationship->get('data');
 
-		$this->assertTrue(is_array($resources));
-		$this->assertTrue(count($resources) === 1);
+		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Collection', $resources);
+		$this->assertCount(1, $resources->getKeys());
 
 		foreach ($resources as $resource)
 		{
@@ -166,8 +166,8 @@ class RelationshipTest extends \PHPUnit_Framework_TestCase
 
 		$resources = $relationship->get('data');
 
-		$this->assertTrue(is_array($resources));
-		$this->assertTrue(count($resources) === 0);
+		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Collection', $resources);
+		$this->assertCount(0, $resources->getKeys());
 	}
 
 	/**

--- a/tests/unit/RelationshipTest.php
+++ b/tests/unit/RelationshipTest.php
@@ -26,7 +26,7 @@ class RelationshipTest extends \PHPUnit_Framework_TestCase
 
 		$meta = $relationship->get('meta');
 
-		$this->assertSame($relationship->asArray(), array('meta' => $meta));
+		$this->assertSame($relationship->asArray(), array('meta' => $meta->asArray()));
 	}
 
 	/**
@@ -78,7 +78,7 @@ class RelationshipTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertInstanceOf('Art4\JsonApiClient\RelationshipLink', $links);
 
-		$this->assertSame($relationship->asArray(), array('links' => $links));
+		$this->assertSame($relationship->asArray(), array('links' => $links->asArray()));
 	}
 
 	/**

--- a/tests/unit/Resource/CollectionTest.php
+++ b/tests/unit/Resource/CollectionTest.php
@@ -65,9 +65,9 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Identifier', $resource);
 
 		$this->assertSame($collection->asArray(), array(
-			$collection->get(0),
-			$collection->get(1),
-			$collection->get(2),
+			$collection->get(0)->asArray(),
+			$collection->get(1)->asArray(),
+			$collection->get(2)->asArray(),
 		));
 	}
 

--- a/tests/unit/Resource/ItemTest.php
+++ b/tests/unit/Resource/ItemTest.php
@@ -69,9 +69,9 @@ class ItemTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($resource->asArray(), array(
 			'type' => $resource->get('type'),
 			'id' => $resource->get('id'),
-			'attributes' => $resource->get('attributes'),
-			'relationships' => $resource->get('relationships'),
-			'links' => $resource->get('links'),
+			'attributes' => $resource->get('attributes')->asArray(),
+			'relationships' => $resource->get('relationships')->asArray(),
+			'links' => $resource->get('links')->asArray(),
 		));
 	}
 }


### PR DESCRIPTION
Hi there.

For my use case, I need to be able to modify a Document instance after a json string has been parsed and later get a json string output with the changes. *This PR focuses on the json string output*.

The PR, in case you accept it, would modify the **asArray** method in AccessTrait so it returns a only array structure, instead of having some objects in the response. I also modified the tests to adapt to this change.

Now, with *asArray* returning no objects, I added a **__toString** method so I can get the json string representation of the Object.

Finally, I found that the Relationship object was using an array when receiving a collection, so I changed it to have a **Collection** instance instead. I kept the validation to make sure every item in the collection is a *Identifier*. Once again, I reviewed the tests to keep them green.

I intend to prepare another PR to allow Document modifications, so please tell me if you are interested or if I better just keep it in my fork.

Thanks.