### PR TITLE
Take relationship collections as a Collection instance

### DIFF
--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -2,6 +2,7 @@
 
 namespace Art4\JsonApiClient;
 
+use Art4\JsonApiClient\Resource\Collection;
 use Art4\JsonApiClient\Utils\AccessTrait;
 use Art4\JsonApiClient\Utils\MetaTrait;
 use Art4\JsonApiClient\Utils\LinksTrait;
@@ -179,24 +180,17 @@ class Relationship implements AccessInterface
 
 		if ( is_array($data) )
 		{
-			$resource_array = array();
-
-			if ( count($data) > 0 )
+			$collection = new Collection($data);
+			foreach ($collection->getKeys() as $key)
 			{
-				foreach ($data as $data_obj)
+				$obj = $collection->get($key);
+				if (!$obj instanceof Identifier)
 				{
-					$resource_obj = $this->parseData($data_obj);
-
-					if ( ! ($resource_obj instanceof Identifier) )
-					{
-						throw new ValidationException('Data has to be instance of "Resource\\Identifier", "' . gettype($data) . '" given.');
-					}
-
-					$resource_array[] = $resource_obj;
+					throw new ValidationException('Data has to be instance of "Resource\\Identifier", "' . gettype($obj) . '" given.');
 				}
 			}
 
-			return $resource_array;
+			return $collection;
 		}
 
 		if ( ! is_object($data) )

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -208,16 +208,16 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
 		$data_array = $comments->get('data');
 
-		$this->assertTrue(is_array($data_array));
-		$this->assertTrue(count($data_array) === 2);
+		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Collection', $data_array);
+		$this->assertCount(2, $data_array->getKeys());
 
-		$identifier = $data_array[0];
+		$identifier = $data_array->get(0);
 
 		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Identifier', $identifier);
 		$this->assertSame($identifier->get('type'), 'comments');
 		$this->assertSame($identifier->get('id'), '5');
 
-		$identifier = $data_array[1];
+		$identifier = $data_array->get(1);
 
 		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Identifier', $identifier);
 		$this->assertSame($identifier->get('type'), 'comments');

--- a/tests/unit/RelationshipTest.php
+++ b/tests/unit/RelationshipTest.php
@@ -141,8 +141,8 @@ class RelationshipTest extends \PHPUnit_Framework_TestCase
 
 		$resources = $relationship->get('data');
 
-		$this->assertTrue(is_array($resources));
-		$this->assertTrue(count($resources) === 1);
+		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Collection', $resources);
+		$this->assertCount(1, $resources->getKeys());
 
 		foreach ($resources as $resource)
 		{
@@ -166,8 +166,8 @@ class RelationshipTest extends \PHPUnit_Framework_TestCase
 
 		$resources = $relationship->get('data');
 
-		$this->assertTrue(is_array($resources));
-		$this->assertTrue(count($resources) === 0);
+		$this->assertInstanceOf('Art4\JsonApiClient\Resource\Collection', $resources);
+		$this->assertCount(0, $resources->getKeys());
 	}
 
 	/**


### PR DESCRIPTION
Change the Relationship object to use a Collection instance instead of an array.

I kept the validation to make sure every item in the collection is a Identifier and reviewed the tests to keep them green.