### PR TITLE
Drop PHP 5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.4
     - php: 5.5
     - php: 5.6
       env: COLLECT_COVERAGE=true


### PR DESCRIPTION
[PHP 5.4 has reached end of life](https://secure.php.net/supported-versions.php) 2 weeks ago. This PR will just stop testing the library in Travis with PHP 5.4 but keep the requirement in `composer.json` at 5.4.

This way the library could still be used with PHP 5.4 but I won't support it anymore.