### PR TITLE
Bugfix with optional Resource ID

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -205,11 +205,12 @@ final class Document implements DocumentInterface
 			throw new ValidationException('Data value has to be null or an object, "' . gettype($data) . '" given.');
 		}
 
-		$object_vars = get_object_vars($data);
+		$object_keys = array_keys(get_object_vars($data));
+		sort($object_keys);
 
 		// the properties must be type and id or
 		// the 3 properties must be type, id and meta
-		if ( count($object_vars) === 2 or (count($object_vars) === 3 and property_exists($data, 'meta')) )
+		if ( $object_keys === ['id', 'type'] or $object_keys === ['id', 'meta', 'type'] )
 		{
 			$resource = $this->manager->getFactory()->make(
 				'ResourceIdentifier',

--- a/tests/Integration/ParsingTest.php
+++ b/tests/Integration/ParsingTest.php
@@ -612,4 +612,19 @@ class ParsingTest extends \Art4\JsonApiClient\Tests\Fixtures\TestCase
 		// Test full array
 		$this->assertEquals(json_decode($string, true), $document->asArray(true));
 	}
+
+	/**
+	 * @test
+	 */
+	public function testParseCreateShortResourceWithoutId()
+	{
+		$string = $this->getJsonString('15_create_resource_without_id.json');
+		$document = Helper::parseRequestBody($string);
+
+		$this->assertInstanceOf('Art4\JsonApiClient\Document', $document);
+		$this->assertSame(['data'], $document->getKeys());
+
+		// Test full array
+		$this->assertEquals(json_decode($string, true), $document->asArray(true));
+	}
 }

--- a/tests/files/15_create_resource_without_id.json
+++ b/tests/files/15_create_resource_without_id.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "type": "photos",
+    "attributes": {
+      "title": "Ember Hamster",
+      "src": "http://example.com/images/productivity.png"
+    }
+  }
+}


### PR DESCRIPTION
Better decision if `data` is a `ResourceIdentifer` or `ResourceItem`.