### PR TITLE
Fix namespaces in docblocks

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -27,9 +27,9 @@ interface Element
     /**
      * Sets the manager and parent
      *
-     * @param mixed                         $data    The data for this Element
-     * @param Art4\JsonApiClient\Manager    $manager The manager
-     * @param Art4\JsonApiClient\Accessable $parent  The parent
+     * @param mixed                          $data    The data for this Element
+     * @param \Art4\JsonApiClient\Manager    $manager The manager
+     * @param \Art4\JsonApiClient\Accessable $parent  The parent
      */
     public function __construct($data, Manager $manager, Accessable $parent);
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -32,7 +32,7 @@ interface Factory
      * @param string $name
      * @param array  $args
      *
-     * @return Art4\JsonApiClient\Accessable
+     * @return \Art4\JsonApiClient\Accessable
      */
     public function make($name, array $args = []);
 }

--- a/src/Helper/AbstractElement.php
+++ b/src/Helper/AbstractElement.php
@@ -33,21 +33,21 @@ abstract class AbstractElement implements Accessable, Element
     use AccessableTrait;
 
     /**
-     * @var Art4\JsonApiClient\Manager
+     * @var \Art4\JsonApiClient\Manager
      */
     private $manager;
 
     /**
-     * @var Art4\JsonApiClient\Accessable
+     * @var \Art4\JsonApiClient\Accessable
      */
     private $parent;
 
     /**
      * Sets the manager and parent
      *
-     * @param mixed                         $data    The data for this Element
-     * @param Art4\JsonApiClient\Manager    $manager The manager
-     * @param Art4\JsonApiClient\Accessable $parent  The parent
+     * @param mixed                          $data    The data for this Element
+     * @param \Art4\JsonApiClient\Manager    $manager The manager
+     * @param \Art4\JsonApiClient\Accessable $parent  The parent
      */
     public function __construct($data, Manager $manager, Accessable $parent)
     {
@@ -60,7 +60,7 @@ abstract class AbstractElement implements Accessable, Element
     /**
      * Returns the Manager
      *
-     * @return Art4\JsonApiClient\Manager
+     * @return \Art4\JsonApiClient\Manager
      */
     protected function getManager()
     {
@@ -70,7 +70,7 @@ abstract class AbstractElement implements Accessable, Element
     /**
      * Get the parent
      *
-     * @return Art4\JsonApiClient\Accessable
+     * @return \Art4\JsonApiClient\Accessable
      */
     protected function getParent()
     {
@@ -83,7 +83,7 @@ abstract class AbstractElement implements Accessable, Element
      * @param mixed $name
      * @param mixed $data
      *
-     * @return Art4\JsonApiClient\Accessable
+     * @return \Art4\JsonApiClient\Accessable
      */
     protected function create($name, $data)
     {

--- a/src/Helper/Parser.php
+++ b/src/Helper/Parser.php
@@ -33,7 +33,7 @@ final class Parser
     /**
      * @param string $jsonString
      *
-     * @throws Art4\JsonApiClient\Exception\Exception
+     * @throws \Art4\JsonApiClient\Exception\Exception
      *
      * @return \Art4\JsonApiClient\Accessable
      */
@@ -47,7 +47,7 @@ final class Parser
     /**
      * @param string $jsonString
      *
-     * @throws Art4\JsonApiClient\Exception\Exception
+     * @throws \Art4\JsonApiClient\Exception\Exception
      *
      * @return \Art4\JsonApiClient\Accessable
      */

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -29,18 +29,18 @@ interface Manager
     /**
      * Parse the input
      *
-     * @param Art4\JsonApiClient\Input\Input $input
+     * @param \Art4\JsonApiClient\Input\Input $input
      *
-     * @throws Art4\JsonApiClient\Exception\ValidationException If $input contains invalid JSON API
+     * @throws \Art4\JsonApiClient\Exception\ValidationException If $input contains invalid JSON API
      *
-     * @return Art4\JsonApiClient\Accessable
+     * @return \Art4\JsonApiClient\Accessable
      */
     public function parse(Input $input);
 
     /**
      * Get a factory from the manager
      *
-     * @return Art4\JsonApiClient\Factory
+     * @return \Art4\JsonApiClient\Factory
      */
     public function getFactory();
 

--- a/src/Manager/ErrorAbortManager.php
+++ b/src/Manager/ErrorAbortManager.php
@@ -42,7 +42,7 @@ final class ErrorAbortManager implements Manager
     /**
      * Create a Manager
      *
-     * @param Art4\JsonApiClient\Factory $factory
+     * @param \Art4\JsonApiClient\Factory $factory
      * @param mixed                      $params  A config array
      *
      * @return object
@@ -55,9 +55,9 @@ final class ErrorAbortManager implements Manager
     /**
      * Parse the input
      *
-     * @param Art4\JsonApiClient\Input\Input $input
+     * @param \Art4\JsonApiClient\Input\Input $input
      *
-     * @throws Art4\JsonApiClient\Exception\ValidationException If $input contains invalid JSON API
+     * @throws \Art4\JsonApiClient\Exception\ValidationException If $input contains invalid JSON API
      *
      * @return \Art4\JsonApiClient\Accessable
      */
@@ -86,7 +86,7 @@ final class ErrorAbortManager implements Manager
     /**
      * Get a factory from the manager
      *
-     * @return Art4\JsonApiClient\Factory
+     * @return \Art4\JsonApiClient\Factory
      */
     public function getFactory()
     {

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -45,7 +45,7 @@ final class ArraySerializer implements Serializer
     /**
      * Convert data in an array
      *
-     * @param Art4\JsonApiClient\Accessable $data The data for serialization
+     * @param \Art4\JsonApiClient\Accessable $data The data for serialization
      *
      * @return array
      */

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -26,7 +26,7 @@ interface Serializer
     /**
      * Serialize data
      *
-     * @param Art4\JsonApiClient\Accessable $data The data for serialization
+     * @param \Art4\JsonApiClient\Accessable $data The data for serialization
      *
      * @return array
      */

--- a/src/V1/Factory.php
+++ b/src/V1/Factory.php
@@ -69,7 +69,7 @@ final class Factory implements FactoryInterface
      * @param string $name
      * @param array  $args
      *
-     * @return Art4\JsonApiClient\Accessable
+     * @return \Art4\JsonApiClient\Accessable
      */
     public function make($name, array $args = [])
     {

--- a/src/V1/ResourceNull.php
+++ b/src/V1/ResourceNull.php
@@ -32,9 +32,9 @@ final class ResourceNull implements Accessable, Element
     /**
      * Constructor
      *
-     * @param mixed                         $data    The data for this Element
-     * @param Art4\JsonApiClient\Manager    $manager The manager
-     * @param Art4\JsonApiClient\Accessable $parent  The parent
+     * @param mixed                          $data    The data for this Element
+     * @param \Art4\JsonApiClient\Manager    $manager The manager
+     * @param \Art4\JsonApiClient\Accessable $parent  The parent
      */
     public function __construct($data, Manager $manager, Accessable $parent)
     {


### PR DESCRIPTION
There seems to be a mistake in several docblocks where the FQCN are missing the leading backslash which screws up autocompletion in IDE and results in codecheck utils (tested with PHPStorm and PHPStan).

This PR just adds that missing backslash where needed.