### PR TITLE
Add support for PHP 8.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 /.docker            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/.travis.yml        export-ignore
+/.phpstan.neon      export-ignore
 /docker-compose.yml export-ignore
 /docs               export-ignore
 /phpunit.xml        export-ignore

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -7,48 +7,30 @@ on:
 jobs:
 
   tests:
-    name: Run with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
+    name: Run PHPStan with PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.4', '8.0', '8.1']
+        php: ['8.2']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-
-      - name: Setup PHP, with composer and extensions
+      - name: Setup PHP with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
-          php-version: ${{ matrix.php-versions }}
-          tools: phpunit
-          extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite
+          php-version: ${{ matrix.php }}
           coverage: xdebug
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          # Use composer.json for key, if composer.lock is not committed.
-          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          tools: none
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
+        uses: "ramsey/composer-install@v2"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan.phar analyze src --level 8
-
-      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -33,4 +33,4 @@ jobs:
         uses: "ramsey/composer-install@v2"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan.phar analyze src --level 8
+        run: composer run phpstan

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,48 +7,37 @@ on:
 jobs:
 
   tests:
-    name: Tests (PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }})
+    name: Tests (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-
-      - name: Setup PHP, with composer and extensions
+      - name: Setup PHP with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
-          php-version: ${{ matrix.php-versions }}
-          tools: phpunit
-          extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite
+          php-version: ${{ matrix.php }}
           coverage: xdebug
+          tools: none
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: "Install Composer dependencies"
+        if: ${{ matrix.php < '8.3' }}
+        uses: "ramsey/composer-install@v2"
 
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
+      - name: "Install Composer dependencies (PHP 8.3)"
+        if: ${{ matrix.php >= '8.3' }}
+        uses: "ramsey/composer-install@v2"
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          # Use composer.json for key, if composer.lock is not committed.
-          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install Composer dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
+          composer-options: --ignore-platform-reqs
 
       - name: Run tests
-        run: vendor/bin/phpunit --coverage-text
-
-      - run: echo "🍏 This job's status is ${{ job.status }}."
+        run: composer run phpunit -- --coverage-text

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,0 +1,29 @@
+parameters:
+	level: 8
+
+	paths:
+		- src/
+
+	scanDirectories:
+		- vendor
+
+	ignoreErrors:
+		-
+			message: "#^Class Art4\\\\JsonApiClient\\\\Helper\\\\AccessKey extends generic class SplStack but does not specify its types\\: TValue$#"
+			count: 1
+			path: src/Helper/AccessKey.php
+
+		-
+			message: "#^Property Art4\\\\JsonApiClient\\\\V1\\\\ResourceNull\\:\\:\\$data is never read, only written\\.$#"
+			count: 1
+			path: src/V1/ResourceNull.php
+
+		-
+			message: "#^Property Art4\\\\JsonApiClient\\\\V1\\\\ResourceNull\\:\\:\\$manager is never read, only written\\.$#"
+			count: 1
+			path: src/V1/ResourceNull.php
+
+		-
+			message: "#^Property Art4\\\\JsonApiClient\\\\V1\\\\ResourceNull\\:\\:\\$parent is never read, only written\\.$#"
+			count: 1
+			path: src/V1/ResourceNull.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add support for PHP 8.2 and PHP 8.3
+- Add support for PHP 8.2
 
 ## [1.1.0 - 2021-10-05](https://github.com/Art4/json-api-client/compare/1.0.0...1.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/Art4/json-api-client/compare/1.1.0...v1.x)
 
+### Added
+
+- Add support for PHP 8.2 and PHP 8.3
+
 ## [1.1.0 - 2021-10-05](https://github.com/Art4/json-api-client/compare/1.0.0...1.1.0)
 
 ### Added
 
 - Added type hints for parameters and return types in internal and final classes
 - New tests for improving backward compatibility in interfaces
-- Support for PHP 8.1 is added in CI tests
+- Add support for PHP 8.1
 
 ### Changed
 
@@ -21,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Deprecated
 
--  `\Art4\JsonApiClient\Accessable::has()` will add `bool` as a native return type declaration in v2.0, do the same in your implementation now to avoid errors.
+- `\Art4\JsonApiClient\Accessable::has()` will add `bool` as a native return type declaration in v2.0, do the same in your implementation now to avoid errors.
 - `\Art4\JsonApiClient\Accessable::getKeys()` will add `array` as a native return type declaration in v2.0, do the same in your implementation now to avoid errors.
 - `\Art4\JsonApiClient\Exception\Exception` will extend `\Throwable` in v2.0, do the same in your implementation now to avoid errors.
 - `\Art4\JsonApiClient\Factory::make()` methods first parameter signature will be `string` in v2.0.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
-        "phpstan/phpstan": "^0.12.99",
+        "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9"
     },
     "autoload": {
@@ -31,7 +31,7 @@
         }
     },
     "scripts": {
-        "phpstan": "phpstan analyze --memory-limit 512M analyze src --level 8",
+        "phpstan": "phpstan analyze src --memory-limit 512M --level 8",
         "phpunit": "phpunit"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "scripts": {
-        "phpstan": "phpstan analyze src --memory-limit 512M --level 8",
+        "phpstan": "phpstan analyze --memory-limit 512M --configuration .phpstan.neon",
         "phpunit": "phpunit"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
@@ -30,10 +30,11 @@
             "Art4\\JsonApiClient\\Tests\\": "tests"
         }
     },
+    "scripts": {
+        "phpstan": "phpstan analyze --memory-limit 512M analyze src --level 8",
+        "phpunit": "phpunit"
+    },
     "config": {
-        "//platform": {
-            "php": "7.4"
-        },
         "sort-packages": true
     }
 }

--- a/src/V1/Factory.php
+++ b/src/V1/Factory.php
@@ -54,7 +54,7 @@ final class Factory implements FactoryInterface
     ];
 
     /**
-     * @param array<string, string> $overload specs to be overloaded with custom classes
+     * @param array<string, class-string> $overload specs to be overloaded with custom classes
      */
     public function __construct(array $overload = [])
     {

--- a/tests/Fixtures/TestCase.php
+++ b/tests/Fixtures/TestCase.php
@@ -19,6 +19,7 @@
 
 namespace Art4\JsonApiClient\Tests\Fixtures;
 
+#[\AllowDynamicProperties]
 class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**


### PR DESCRIPTION
This PR adds support for PHP 8.2 and runs the tests with PHP 8.3. It also updates PHPStan for compatability reasons with PHP 8.2, but it now reports 4 errors. These errors will be fixed in a separate PR.